### PR TITLE
Don't fail if other libc than glibc is installed

### DIFF
--- a/configure
+++ b/configure
@@ -108,7 +108,6 @@ for dir in ${DIRS}; do
 done
 if [[ -z $NSSFILES ]]; then
   echo "not found"
-  exit 1
 else
   echo $NSSFILES
 fi

--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -104,7 +104,12 @@ install() {
   rm -rf $tmpDir
   
   #install the required binaries
-  dracut_install pkill setterm /lib64/libnss_files.so.2
+  dracut_install pkill setterm
+  if [ -f /lib$(getconf LONG_BIT)/libnss_files.so.2 ]; then
+    dracut_install /lib$(getconf LONG_BIT)/libnss_files.so.2
+  elif [ -f /lib/libnss_files.so.2 ]; then
+    dracut_install /lib/libnss_files.so.2
+  fi
   inst $(which dropbear) /sbin/dropbear
   #install the required helpers
   inst "$moddir"/helper/console_auth /bin/console_auth


### PR DESCRIPTION
libnss_files.so.2 is glibc specific, other libcs don't have it. I also changed /lib64 to /lib in module-setup.sh, because /lib is usually a symlink to the platform specific folder.
