### PR TITLE
Do not supply parameter -m.

### DIFF
--- a/modules/60crypt-ssh/dropbear-start.sh
+++ b/modules/60crypt-ssh/dropbear-start.sh
@@ -12,6 +12,6 @@
     info "  bubblebabble: ${bubble}"
   done
 
-  /sbin/dropbear -m -s -j -k -p ${dropbear_port} -P /tmp/dropbear.pid
+  /sbin/dropbear -s -j -k -p ${dropbear_port} -P /tmp/dropbear.pid
   [ $? -gt 0 ] && info 'Dropbear sshd failed to start'
 }


### PR DESCRIPTION
There exist dropbear builds which do not support this parameter and subsequently fail resulting in an unreachable system.