### PR TITLE
Specify PEM format for ssh-keygen, to ensure private key can be read by dropbearconvert

### DIFF
--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -40,7 +40,7 @@ install() {
     
     case ${state} in
       GENERATE )
-        ssh-keygen -t $keyType -f $osshKey -q -N "" || {
+        ssh-keygen -t $keyType -f $osshKey -q -N "" -m PEM || {
           derror "SSH ${msgKeyType} key creation failed"
           rm -rf "$tmpDir"
           return 1


### PR DESCRIPTION
Fixes issue #32 