### PR TITLE
fixes for #38: make sure string is interpreted as base10 integer, avoiding error with dracut version 049

### DIFF
--- a/configure
+++ b/configure
@@ -114,7 +114,7 @@ else
 fi
 
 OLDDRACUT=0
-[[ $DRACUT_VERSION -le 4 ]] && OLDDRACUT=1
+[[ 10#$DRACUT_VERSION -le 4 ]] && OLDDRACUT=1
 
 cat >config.mk <<EOF
 export DRACUT=${DRACUT}


### PR DESCRIPTION
Current implementation leads to error when e.g. DRACUT_VERSION == 049, since 049 will be interpreted as an (invalid) octal value in bash.