### PR TITLE
Correctly link with --as-needed

### DIFF
--- a/modules/60crypt-ssh/helper/Makefile
+++ b/modules/60crypt-ssh/helper/Makefile
@@ -20,7 +20,7 @@ console_auth:	auth.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 unlock:	crypttab.o unlock.o
-	$(CC) $(CFLAGS) -lblkid $^ -o $@
+	$(CC) $(CFLAGS) $^ -lblkid -o $@
 
 crypttab-test: crypttab-test.c crypttab.o crypttab-test-data
 	$(CC) crypttab-test.c $(CFLAGS) crypttab.o -lblkid -o crypttab-test


### PR DESCRIPTION
Linker needs to analzye the objects first before considering libraries.
as-needed is commonly used on distros.