### PR TITLE
Fix installation of libnss_files

### DIFF
--- a/configure
+++ b/configure
@@ -94,25 +94,6 @@ else
 fi
 echo ${ROOTHOME}
 
-
-echo -n "Checking for libnss_files.so ... "
-DIRS="/usr/lib /usr/lib64 /lib64 /lib"
-NSSFILES=""
-for dir in ${DIRS}; do
-  for check in ${dir}/libnss_files.so*; do
-    if [[ -f $check ]]; then
-      NSSFILES=${check}
-      break
-    fi
-  done
-done
-if [[ -z $NSSFILES ]]; then
-  echo "not found"
-  exit 1
-else
-  echo $NSSFILES
-fi
-
 cat >config.mk <<EOF
 export DRACUT=${DRACUT}
 export DRACUT_VERSION=${DRACUT_VERSION}
@@ -120,5 +101,4 @@ export DRACUT_MODULEDIR=${DRACUT_MODULEDIR}
 export NEED_CRYPTSETTLE=${NEED_CRYPTSETTLE}
 export ROOTHOME=${ROOTHOME}
 export OLDSTYLE=${OLDSTYLE}
-export NSSFILES=${NSSFILES}
 EOF

--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -104,8 +104,18 @@ install() {
   rm -rf $tmpDir
   
   #install the required binaries
-  dracut_install pkill setterm /lib64/libnss_files.so.2
-  inst $(which dropbear) /sbin/dropbear
+  dracut_install pkill setterm
+  inst_libdir_file "libnss_files*"
+
+  #dropbear should always be in /sbin so the start script works
+  local dropbear
+  if dropbear="$(command -v dropbear 2>/dev/null)"; then
+    inst "${dropbear}" /sbin/dropbear
+  else
+    derror "Unable to locate dropbear executable"
+    return 1
+  fi
+
   #install the required helpers
   inst "$moddir"/helper/console_auth /bin/console_auth
   inst "$moddir"/helper/console_peek.sh /bin/console_peek


### PR DESCRIPTION
On glibc, dropbear seems to depend on the existence of libnss_files to be able to read the password database and authorize logins. Rather than hard-code the path and version, rely on the `inst_libdir_file` dracut function, which should find the file if it exists and should fail gracefully on other C libraries (like musl) where it doesn't. This is how the build-in 95udev dracut module installs the library.

Closes #6.