### PR TITLE
Added workaround for ED25519 key failed error (CentOS stream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,18 +302,25 @@ naming mixup, no traffic (e.g. unrelated connection issue), etc.
 ## 5.4 *dracut: dropbearconvert for ED25519 key failed*
 
 In the case that your dropbearconvert does not support ED25519 encryption (e.g CentOS Stream), you will need to install
-dropbear from source upstream of [this PR](https://github.com/mkj/dropbear/pull/91).  
+dropbear from source upstream of [this PR](https://github.com/mkj/dropbear/pull/91).  We will use the `DROPBEAR_2020.81` tag in the example below.
 
 1. Clone [dropbear git repo](https://github.com/mkj/dropbear)
 
-2. Intsall from source. 
+2. Check out the latest release tag
    ```
-   ./configure --prefix /usr  # sudo has only /sbin:/bin:/usr/sbin:/usr/bin and default prefix is /usr/local
+   git checkout DROPBEAR_2020.81
+   ```
+
+2. Install from source. 
+   ```
+   ./configure 
    make
    sudo make install
    ```
 
 3. Now re-run `dracut --force`
+Since the sudo user only has the following items in path `/sbin:/bin:/usr/sbin:/usr/bin` and our version of dropbear is installed in `/usr/local/bin`, we need to extend the path of the sudo user for this command to ensure the right version of dropbear is used. We can do this with the following command:
+`sudo PATH="/usr/local/bin:$(sudo bash -c 'echo "$PATH"')' dracut --force`
    
 
 ## 5.5 Report a bug

--- a/README.md
+++ b/README.md
@@ -297,7 +297,30 @@ either enable "debug" dracut module or add `dracut_install netstat ip` line to
 (for "rdsosreport.sh") show - there can be no default route, whatever interface
 naming mixup, no traffic (e.g. unrelated connection issue), etc.
 
-## 5.4 Report a bug
+## 5.4 *dracut: dropbearconvert for ED25519 key failed*
+
+In the case that your dropbearconvert does not support ED25519 encryption (e.g CentOS Stream), you will need to install
+dropbear from source upstream of [this PR](https://github.com/mkj/dropbear/pull/91).  
+
+1. Clone and install [dropbear](https://github.com/mkj/dropbear) from source
+2. Ensuring dracut uses the latest version of dropbear:
+   At the end of your `make install` script for dropbear you will note the following lines:
+   ```
+   install dropbear /usr/local/sbin
+   install dbclient /usr/local/bin
+   install dropbearkey /usr/local/bin
+   install dropbearconvert /usr/local/bin
+   ```
+   To ensure that `dracut` uses the latest version of dropbear, we will link these last three to `/usr/local/sbin`
+   ```
+   sudo ln -s /usr/local/bin/dbclient /usr/local/sbin/dbclient
+   sudo ln -s /usr/local/bin/dropbearkey /usr/local/sbin/dropbearkey
+   sudo ln -s /usr/local/bin/dropbearconvert /usr/local/sbin/dropbearconvert
+   ```
+3. Now re-run `dracut --force`
+   
+
+## 5.5 Report a bug
 
 If you suspect a bug in the software, please [report it via our issue 
 tracker](https://github.com/dracut-crypt-ssh/dracut-crypt-ssh/issues).

--- a/README.md
+++ b/README.md
@@ -319,8 +319,13 @@ dropbear from source upstream of [this PR](https://github.com/mkj/dropbear/pull/
    ```
 
 3. Now re-run `dracut --force`
-Since the sudo user only has the following items in path `/sbin:/bin:/usr/sbin:/usr/bin` and our version of dropbear is installed in `/usr/local/bin`, we need to extend the path of the sudo user for this command to ensure the right version of dropbear is used. We can do this with the following command:
-`sudo PATH="/usr/local/bin:$(sudo bash -c 'echo "$PATH"')' dracut --force`
+
+Since the sudo user only has the following items in path `/sbin:/bin:/usr/sbin:/usr/bin` and our version of dropbear is installed in `/usr/local/bin`, we need to extend the path of the sudo user for this command to ensure the right version of dropbear is used. 
+
+We can do this with the following command:
+```
+sudo PATH="/usr/local/bin:$(sudo bash -c 'echo "$PATH"')' dracut --force
+```
    
 
 ## 5.5 Report a bug

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ command="unlock" to your authorized_keys before the key, e.g.
 
     command="unlock" ssh-rsa .....
 
+> In some cases (CentOS stream) you may wish to replace `unlock` with `systemd-tty-ask-password-agent`
+
 # 4. Configuration
 
 The configuration is stored in the crypt-ssh.conf, usually located in `/etc/dracut.conf.d/`.

--- a/README.md
+++ b/README.md
@@ -302,21 +302,15 @@ naming mixup, no traffic (e.g. unrelated connection issue), etc.
 In the case that your dropbearconvert does not support ED25519 encryption (e.g CentOS Stream), you will need to install
 dropbear from source upstream of [this PR](https://github.com/mkj/dropbear/pull/91).  
 
-1. Clone and install [dropbear](https://github.com/mkj/dropbear) from source
-2. Ensuring dracut uses the latest version of dropbear:
-   At the end of your `make install` script for dropbear you will note the following lines:
+1. Clone [dropbear git repo](https://github.com/mkj/dropbear)
+
+2. Intsall from source. 
    ```
-   install dropbear /usr/local/sbin
-   install dbclient /usr/local/bin
-   install dropbearkey /usr/local/bin
-   install dropbearconvert /usr/local/bin
+   ./configure --prefix /usr  # sudo has only /sbin:/bin:/usr/sbin:/usr/bin and default prefix is /usr/local
+   make
+   sudo make install
    ```
-   To ensure that `dracut` uses the latest version of dropbear, we will link these last three to `/usr/local/sbin`
-   ```
-   sudo ln -s /usr/local/bin/dbclient /usr/local/sbin/dbclient
-   sudo ln -s /usr/local/bin/dropbearkey /usr/local/sbin/dropbearkey
-   sudo ln -s /usr/local/bin/dropbearconvert /usr/local/sbin/dropbearconvert
-   ```
+
 3. Now re-run `dracut --force`
    
 


### PR DESCRIPTION
Workaround for: 
* https://github.com/dracut-crypt-ssh/dracut-crypt-ssh/issues/34
* https://github.com/dracut-crypt-ssh/dracut-crypt-ssh/issues/39 
