### PR TITLE
Make list of key types a configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,13 @@ The configuration is stored in the crypt-ssh.conf, usually located in `/etc/drac
 
 The following options are available (see the config file for detailed description):
  - `dropbear_port` (default: `222`) - port ssh daemon should listen on
+ - `dropbear_keytypes` (default: `rsa ecdsa ed25519`) - A space-separated list of the SSH key types which will be installed in the initramfs
  - `dropbear_rsa_key`, `dropbear_ecdsa_key`, `dropbear_ed25519_key` (default: `GENERATE`) - Source of the keys, possible options:
    - `SYSTEM` - copy the private keys from the encrypted system (not recommended)
    - `GENERATE` - generate a new keys (during the creation of initramfs)
    - path - key file in OpenSSH format as generared by ssh-keygen (a public file with '.pub' ending must be present too)
+
+   If any key type is not included in `dropbear_keytypes`, the corresponding `dropbear_<type>_key` variable is ignored
  - `dropbear_acl` (default: `/root/.ssh/authorized_keys`) - Keys which allowed to login into initramfs
 
 After any configuration change, you have to rebuild the initramfs as the

--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
 
 # called by dracut
 check() {
@@ -18,17 +19,24 @@ install() {
   [[ -z "${dropbear_port}" ]] && dropbear_port=222
   [[ -z "${dropbear_acl}" ]] && dropbear_acl=/root/.ssh/authorized_keys
   local tmpDir=$(mktemp -d --tmpdir dracut-crypt-ssh.XXXX)
-  local keyTypes="rsa ecdsa ed25519"
   local genConf="${tmpDir}/crypt-ssh.conf"
   local installConf="/etc/crypt-ssh.conf"
 
+  # Make sure dropbear_keytypes has a value and everything is lowercase
+  if [[ -z "${dropbear_keytypes}" ]]; then
+    dropbear_keytypes="rsa ecdsa ed25519"
+  else
+    dropbear_keytypes="$(echo "${dropbear_keytypes}" | tr '[:upper:]' '[:lower:]')"
+  fi
+
   #start writing the conf for initramfs include
   echo -e "#!/bin/bash\n\n" > $genConf
-  echo "keyTypes='${keyTypes}'" >> $genConf
+  echo "keyTypes='${dropbear_keytypes}'" >> $genConf
   echo "dropbear_port='${dropbear_port}'" >> $genConf
 
   #go over different encryption key types
-  for keyType in $keyTypes; do
+  for keyType in $dropbear_keytypes; do
+    keyType=$(echo "$keyType" | tr '[:upper:]' '[:lower:]')
     eval state=\$dropbear_${keyType}_key
     local msgKeyType=$(echo "$keyType" | tr '[:lower:]' '[:upper:]')
 


### PR DESCRIPTION
Rather than hard-code RSA, ECDSA and ED25519 keys, allow a `dropbear_keytypes` variable that can specify a subset of these types to limit what is converted and copied into the initramfs.