### PR TITLE
Show an error message if unlock could not find cryptsetup

### DIFF
--- a/modules/60crypt-ssh/helper/unlock.c
+++ b/modules/60crypt-ssh/helper/unlock.c
@@ -155,6 +155,12 @@ int main( int argc, const char ** argv )
 			NULL
 		};
 
+		if( access( path, X_OK ) != 0 ) {
+			fprintf( stderr, "Could not find %s\n", path );
+			errorExit = 1;
+			break;
+		}
+
 		int result = runchild( password, passwordSize, path, args );
 		if( result ) {
 			fprintf( stderr, "Could not open %s (%s)\n", entry->mapper, entry->real_device );


### PR DESCRIPTION
As it had costs me some nerves to figure out the real issue in my setup, I thought it could be helpful to others to have an additional error message in unlock.

```
-sh-5.1# echo -n 123456 | unlock
Warning: Unable to lock memory, are you root?
Could not find /sbin/cryptsetup
-sh-5.1# 
```