### PR TITLE
disable TIOCSTI again if we were the ones who enabled it

### DIFF
--- a/modules/60crypt-ssh/dropbear-start.sh
+++ b/modules/60crypt-ssh/dropbear-start.sh
@@ -4,7 +4,10 @@
 
 # Linux >= 6.2 allows the TIOCSTI ioctl to be disabled by default;
 # console_auth requires it, so re-enable using the provided sysctl
-[ -w /proc/sys/dev/tty/legacy_tiocsti ] && echo 1 > /proc/sys/dev/tty/legacy_tiocsti
+if [ -w /proc/sys/dev/tty/legacy_tiocsti ]; then
+  cp /proc/sys/dev/tty/legacy_tiocsti /tmp/legacy_tiocsti.default >/dev/null 2>&1
+  echo 1 > /proc/sys/dev/tty/legacy_tiocsti
+fi
 
 [ -f /tmp/dropbear.pid ] && kill -0 $(cat /tmp/dropbear.pid) 2>/dev/null || {
   info "sshd port: ${dropbear_port}"

--- a/modules/60crypt-ssh/dropbear-stop.sh
+++ b/modules/60crypt-ssh/dropbear-stop.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -r /tmp/legacy_tiocsti.default ] && [ -w /proc/sys/dev/tty/legacy_tiocsti ]; then
+  cat /tmp/legacy_tiocsti.default > /proc/sys/dev/tty/legacy_tiocsti
+fi
+
 [ -f /tmp/dropbear.pid ] || exit 0
 read main_pid < /tmp/dropbear.pid
 kill -STOP ${main_pid} 2>/dev/null


### PR DESCRIPTION
I tried the
```
echo "w /proc/sys/dev/tty/legacy_tiocsti - - - - 0" > /etc/tmpfiles.d/tiocsti.conf
```
to disable tiocsti on boot, but it didn't work for whatever reason (Fedora 38), so i created a systemd oneshot service that does it.

But i don't like that. I would prefer it if dracut-crypt-ssh would itself be smart enough to disable it again if it enabled it.
This PR does that.