### PR TITLE
fix duplicate const compiler warning

### DIFF
--- a/modules/60crypt-ssh/helper/crypttab.c
+++ b/modules/60crypt-ssh/helper/crypttab.c
@@ -117,7 +117,7 @@ void crypttab_free( struct crypttab *list )
 }
 
 
-struct crypttab crypttab_parse( const char *filename )
+struct crypttab crypttab_parse( const char * const filename )
 {
 	struct crypttab list;
 	char lineBuf[ PATH_MAX ];

--- a/modules/60crypt-ssh/helper/crypttab.c
+++ b/modules/60crypt-ssh/helper/crypttab.c
@@ -117,7 +117,7 @@ void crypttab_free( struct crypttab *list )
 }
 
 
-struct crypttab crypttab_parse( const char const*filename )
+struct crypttab crypttab_parse( const char *filename )
 {
 	struct crypttab list;
 	char lineBuf[ PATH_MAX ];

--- a/modules/60crypt-ssh/helper/crypttab.h
+++ b/modules/60crypt-ssh/helper/crypttab.h
@@ -15,7 +15,7 @@ struct crypttab {
 	int size;
 };
 
-struct crypttab crypttab_parse( const char *filename );
+struct crypttab crypttab_parse( const char * const filename );
 void crypttab_lookupblkids( struct crypttab *list );
 void crypttab_free( struct crypttab *list );
 void crypttab_freeentry( struct crypttab_entry *entry );

--- a/modules/60crypt-ssh/helper/crypttab.h
+++ b/modules/60crypt-ssh/helper/crypttab.h
@@ -15,7 +15,7 @@ struct crypttab {
 	int size;
 };
 
-struct crypttab crypttab_parse( const char const*filename );
+struct crypttab crypttab_parse( const char *filename );
 void crypttab_lookupblkids( struct crypttab *list );
 void crypttab_free( struct crypttab *list );
 void crypttab_freeentry( struct crypttab_entry *entry );


### PR DESCRIPTION
This fixes the following warning issued by gcc: `warning: duplicate ‘const’ declaration specifier [-Wduplicate-decl-specifier]`