### PR TITLE
Busybox Compat

### DIFF
--- a/modules/60crypt-ssh/helper/unlock-reap-success.sh
+++ b/modules/60crypt-ssh/helper/unlock-reap-success.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
 
-SYSTEMD_CRYPTSETUP="$(ps -C systemd-cryptsetup -o pid=)"
-if [ "$?" -eq 0 ]; then
-	# Systemd method
-	kill -9 "${SYSTEMD_CRYPTSETUP}"
-else
-	# Older method
-	pkill cryptroot-ask
-fi
+pkill systemd-cryptsetup || pkill cryptroot-ask
+


### PR DESCRIPTION
Busybox's `ps` command does not support the '-C' argument; it only works with the procps-ng version. Both Busybox and procps-ng ship compatible versions of `pgrep` that provide the same function.