### PR TITLE
fix(unlock-reap-success): naive workaround for Archlinux issues

### DIFF
--- a/modules/60crypt-ssh/helper/unlock-reap-success.sh
+++ b/modules/60crypt-ssh/helper/unlock-reap-success.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
 pkill systemd-cryptsetup || pkill cryptroot-ask
+# Some versions of `pkill` need -f:
+# pkill: pattern that searches for process name longer than 15 characters will result in zero matches
+# Try `pkill -f' option to match against the complete command line.
+pkill -f systemd-cryptsetup || pkill -f cryptroot-ask
 


### PR DESCRIPTION
`pkill` from procps-ng 4.0.4 needs `-f` to search for the full commandline