### PR TITLE
Fix permission of dropbear_acl target file for installation

### DIFF
--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -106,7 +106,10 @@ install() {
   inst_hook pre-udev 99 "$moddir/dropbear-start.sh"
   inst_hook pre-pivot 05 "$moddir/dropbear-stop.sh"
 
+  #install the authorized_keys file and fix the ownership/permission
   inst "${dropbear_acl}" /root/.ssh/authorized_keys
+  chmod 400 ${initdir}/root/.ssh/authorized_keys
+  chown root:root ${initdir}/root/.ssh/authorized_keys
 
   #cleanup
   rm -rf $tmpDir

--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -109,7 +109,7 @@ install() {
   #install the authorized_keys file and fix the ownership/permission
   inst "${dropbear_acl}" /root/.ssh/authorized_keys
   chmod 400 ${initdir}/root/.ssh/authorized_keys
-  chown root:root ${initdir}/root/.ssh/authorized_keys
+  chown 0:0 ${initdir}/root/.ssh/authorized_keys
 
   #cleanup
   rm -rf $tmpDir


### PR DESCRIPTION
* Fix the ownership and permission of the dropbear_acl target file for dracut to use as /root/.ssh/authorized_keys.
* Fixes #78.