### PR TITLE
add /etc/shells to initramfs in order to allow login

### DIFF
--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -126,6 +126,11 @@ install() {
     derror "Unable to locate dropbear executable"
     return 1
   fi
+  
+  # create /etc/shells based on /bin/*sh                                                                               
+  # dropbear checks /etc/passwd shell against /etc/shells                                                              
+  # root user is added to passwd in 60systemd-sysusers/module-setup.sh                                                 
+  [ ! -f "${initdir}"/etc/shells ] && find "${initdir}"/bin/ -type f -name "*sh" -printf "/bin/%P\n" > "${initdir}"/etc/shells      
 
   #install the required helpers
   inst "$moddir"/helper/console_auth /bin/console_auth

--- a/modules/60crypt-ssh/module-setup.sh
+++ b/modules/60crypt-ssh/module-setup.sh
@@ -127,10 +127,14 @@ install() {
     return 1
   fi
   
-  # create /etc/shells based on /bin/*sh                                                                               
-  # dropbear checks /etc/passwd shell against /etc/shells                                                              
-  # root user is added to passwd in 60systemd-sysusers/module-setup.sh                                                 
-  [ ! -f "${initdir}"/etc/shells ] && find "${initdir}"/bin/ -type f -name "*sh" -printf "/bin/%P\n" > "${initdir}"/etc/shells      
+  # add /bin/bash to /etc/shells
+  # dropbear checks /etc/passwd shell against /etc/shells
+  # root user is added to passwd in 60systemd-sysusers/module-setup.sh
+  # if any other shell than /bin/bash is used, it must be added as well
+  if [ ! -f "${initdir}"/etc/shells ] || ! grep -q /bin/bash "${initdir}"/etc/shells
+  then 
+    echo /bin/bash >> "${initdir}"/etc/shells
+  fi
 
   #install the required helpers
   inst "$moddir"/helper/console_auth /bin/console_auth


### PR DESCRIPTION
Fixes https://github.com/dracut-crypt-ssh/dracut-crypt-ssh/issues/84

It is a dropbear specific problem, so despite my former comment, it should be fixed here.

Problem is here:
https://github.com/mkj/dropbear/blob/bd12a8611b3c838f1ed1d1c2cbaff2da1072a315/src/svr-auth.c#L332
i.e.
The /etc/passwd shell is checked against /etc/shells - but /etc/shells does not exist in the initramfs

before:
```bash
lsinitrd /boot/efi/boot/bootx64.efi --file etc/shells
objcopy: /dev/null: file truncated
```

after:
```bash
lsinitrd /boot/efi/boot/bootx64.efi --file etc/shells
objcopy: /dev/null: file truncated
/bin/bash
/bin/sh
```

The commit just `find`s all `/bin/*sh` and adds them to the `/etc/shells`.
The `passwd` does not contain the root account at that point - this will be added by `60systemd-sysusers/module-setup.sh`
So, if `systemd` changes the shell or another shell is used but not available at that point, it might lead to errors.